### PR TITLE
Do not leak submitter IP

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -996,7 +996,7 @@ get  '/api/getnews/:sort/:start/:count' do
     getfunc = method((sort == :latest) ? :get_latest_news : :get_top_news)
     news,numitems = getfunc.call(start,count)
     news.each{|n|
-        ['rank','score','user_id'].each{|field| n.delete(field)}
+        ['rank','score','user_id','ip'].each{|field| n.delete(field)}
     }
     return { :status => "ok", :news => news, :count => numitems }.to_json
 end


### PR DESCRIPTION
I was playing with Echo JS API and noticed that the public endpoint reveals the submitter's IP: https://www.echojs.com/api/getnews/top/0/1